### PR TITLE
Kano UAT feedback improvements and fixes

### DIFF
--- a/apps/health_campaign_field_worker_app/android/app/google-services.json
+++ b/apps/health_campaign_field_worker_app/android/app/google-services.json
@@ -1,8 +1,8 @@
 {
   "project_info": {
-    "project_number": "630326133351",
-    "project_id": "digit-hcm-nigeria",
-    "storage_bucket": "digit-hcm-nigeria.firebasestorage.app"
+    "project_number": "397617237644",
+    "project_id": "digit-health-75ed0",
+    "storage_bucket": "digit-health-75ed0.firebasestorage.app"
   },
   "client": [
     {

--- a/apps/health_campaign_field_worker_app/android/app/google-services.json
+++ b/apps/health_campaign_field_worker_app/android/app/google-services.json
@@ -2,9 +2,10 @@
   "project_info": {
     "project_number": "397617237644",
     "project_id": "digit-health-75ed0",
-    "storage_bucket": "digit-health-75ed0.firebasestorage.app"
+    "storage_bucket": "digit-health-75ed0.appspot.com"
   },
   "client": [
+    
     {
       "client_info": {
         "mobilesdk_app_id": "1:397617237644:android:55bec018a3018ceaf6b5a9",

--- a/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_summary_report_bloc.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_summary_report_bloc.dart
@@ -61,6 +61,7 @@ class SummaryReportBloc extends Bloc<SummaryReportEvent, SummaryReportState> {
       productVariantList = await (productVariantDataRepository)
           .search(ProductVariantSearchModel());
       for (var element in taskList) {
+        if (element.status == null) continue;
         final status = StatusMapper.fromValue(element.status);
 
         if (status == Status.administeredSuccess) {

--- a/apps/health_campaign_field_worker_app/lib/data/repositories/remote/mdms.dart
+++ b/apps/health_campaign_field_worker_app/lib/data/repositories/remote/mdms.dart
@@ -156,7 +156,7 @@ class MdmsRepository {
 
     final firebaseConfig = FirebaseConfig()
       ..enableAnalytics = element?.firebaseConfig?.first.enableAnalytics
-      ..enableCrashlytics = element?.firebaseConfig?.first.enableCrashlytics;
+      ..enableCrashlytics = true;
 
     appConfiguration
       ..networkDetection = appConfig?.networkDetection

--- a/apps/health_campaign_field_worker_app/lib/firebase_options.dart
+++ b/apps/health_campaign_field_worker_app/lib/firebase_options.dart
@@ -50,11 +50,11 @@ class DefaultFirebaseOptions {
   }
 
   static const FirebaseOptions android = FirebaseOptions(
-    apiKey: 'AIzaSyDkT1V6wknoUsh8CFDXiA8OwElZnK9sF9w',
-    appId: '1:630326133351:android:5c043092e0cd437c954ac2',
-    messagingSenderId: '630326133351',
-    projectId: 'digit-hcm-nigeria',
-    storageBucket: 'digit-hcm-nigeria.firebasestorage.app',
+    apiKey: 'AIzaSyBzE5f156_ia7HumLb1fDg8A-88uhmQ68Y',
+    appId: '1:397617237644:android:55bec018a3018ceaf6b5a9',
+    messagingSenderId: '397617237644',
+    projectId: 'digit-health-75ed0',
+    storageBucket: 'digit-health-75ed0.appspot.com',
   );
 
   static const FirebaseOptions ios = FirebaseOptions(

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
@@ -1211,7 +1211,7 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
       List<String> selectedProducts) async {
     final StockDataRepository stockRepository =
         context.repository<StockModel, StockSearchModel>();
-    final productVariantId = products.first.id;
+    final productVariantId = stockModel.productVariantId;
 
     final secondartParty = receivedFrom.contains(("FAC_"))
         ? receivedFrom.replaceFirst("FAC_", "")
@@ -1244,7 +1244,7 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
             element.clientAuditDetails?.createdTime != null &&
             element.clientAuditDetails!.createdTime >=
                 startOfDay.millisecondsSinceEpoch &&
-            element.clientAuditDetails!.createdTime <=
+            element.clientAuditDetails!.createdTime <
                 endOfDay.millisecondsSinceEpoch)
         .toList();
 

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
@@ -1010,22 +1010,22 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
             return;
           }
 
-          if (entryType == StockRecordEntryType.dispatch &&
-              context.isHealthFacilitySupervisor) {
-            if (quantity + quantityIssuedToday >
-                Constants.cddStockTransactionDailyLimit) {
-              await DigitToast.show(
-                context,
-                options: DigitToastOptions(
-                    localizations.translate(i18_local
-                        .stockDetails.stockDispatchToCddDailyLimitValidation),
-                    true,
-                    theme),
-              );
-              isSubmitClicked = false;
-              return;
-            }
-          }
+          // if (entryType == StockRecordEntryType.dispatch &&
+          //     context.isHealthFacilitySupervisor) {
+          //   if (quantity + quantityIssuedToday >
+          //       Constants.cddStockTransactionDailyLimit) {
+          //     await DigitToast.show(
+          //       context,
+          //       options: DigitToastOptions(
+          //           localizations.translate(i18_local
+          //               .stockDetails.stockDispatchToCddDailyLimitValidation),
+          //           true,
+          //           theme),
+          //     );
+          //     isSubmitClicked = false;
+          //     return;
+          //   }
+          // }
 
           if (entryType == StockRecordEntryType.returned ||
               (entryType == StockRecordEntryType.dispatch &&

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
@@ -198,7 +198,6 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
           stock.transactionReason == 'RETURNED' &&
           stock.senderId == secondartParty &&
           stock.receiverId == primaryId;
-      ;
     }).toList();
 
     int totalReturnQuantity = 0;
@@ -944,6 +943,9 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
           final totalQuantityReceived = await getReceivedQuantity(
               context, stockState, stockModel, selectedProducts);
 
+          final quantityIssuedToday = await getQuantityIssuedTodayToCurrentUser(
+              context, stockState, stockModel, selectedProducts);
+
           int quantity = int.parse(stockModel.quantity.toString());
 
           int quantityWasted = int.parse(stockModel.additionalFields?.fields
@@ -1006,6 +1008,23 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
             );
             isSubmitClicked = false;
             return;
+          }
+
+          if (entryType == StockRecordEntryType.dispatch &&
+              context.isHealthFacilitySupervisor) {
+            if (quantity + quantityIssuedToday >
+                Constants.cddStockTransactionDailyLimit) {
+              await DigitToast.show(
+                context,
+                options: DigitToastOptions(
+                    localizations.translate(i18_local
+                        .stockDetails.stockDispatchToCddDailyLimitValidation),
+                    true,
+                    theme),
+              );
+              isSubmitClicked = false;
+              return;
+            }
           }
 
           if (entryType == StockRecordEntryType.returned ||
@@ -1182,6 +1201,57 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
       receivedStocks.where((e) =>
           e.transactionType == TransactionType.received.toValue() &&
           e.transactionReason == TransactionReason.received.toValue()),
+    );
+  }
+
+  Future<num> getQuantityIssuedTodayToCurrentUser(
+      BuildContext context,
+      RecordStockState stockState,
+      StockModel stockModel,
+      List<String> selectedProducts) async {
+    final StockDataRepository stockRepository =
+        context.repository<StockModel, StockSearchModel>();
+    final productVariantId = products.first.id;
+
+    final secondartParty = receivedFrom.contains(("FAC_"))
+        ? receivedFrom.replaceFirst("FAC_", "")
+        : receivedFrom.contains('||')
+            ? receivedFrom.split('||')[1]
+            : receivedFrom;
+
+    final facilityId;
+    if (InventorySingleton().isDistributor) {
+      facilityId = InventorySingleton().loggedInUserUuid;
+    } else {
+      facilityId = stockState.facilityModel?.id;
+    }
+
+    final now = DateTime.now();
+    final startOfDay = DateTime(now.year, now.month, now.day);
+    final endOfDay = startOfDay.add(const Duration(days: 1));
+
+    final issuedStocks = (await stockRepository.search(
+      StockSearchModel(
+          productVariantId: productVariantId,
+          senderId: facilityId, // primaryId,
+          receiverId: secondartParty,
+          transactionType: [TransactionType.dispatched.toValue()]),
+    ))
+        .where((element) =>
+            element.auditDetails != null &&
+            element.auditDetails?.createdBy ==
+                InventorySingleton().loggedInUserUuid &&
+            element.clientAuditDetails?.createdTime != null &&
+            element.clientAuditDetails!.createdTime >=
+                startOfDay.millisecondsSinceEpoch &&
+            element.clientAuditDetails!.createdTime <=
+                endOfDay.millisecondsSinceEpoch)
+        .toList();
+
+    return _getQuantityCount(
+      issuedStocks.where((e) =>
+          e.transactionType == TransactionType.dispatched.toValue() &&
+          e.transactionReason == null),
     );
   }
 

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory_management/custom_stock_details_in_tabs.dart
@@ -1226,6 +1226,8 @@ class _DynamicTabsPageState extends LocalizedState<DynamicTabsPage>
       facilityId = stockState.facilityModel?.id;
     }
 
+    if (productVariantId == null || facilityId == null) return 0;
+
     final now = DateTime.now();
     final startOfDay = DateTime(now.year, now.month, now.day);
     final endOfDay = startOfDay.add(const Duration(days: 1));

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory_management/view_record_lga.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory_management/view_record_lga.dart
@@ -164,7 +164,7 @@ class _ViewStockRecordsLGAPageState
             element.clientAuditDetails?.createdTime != null &&
             element.clientAuditDetails!.createdTime >=
                 startOfDay.millisecondsSinceEpoch &&
-            element.clientAuditDetails!.createdTime <=
+            element.clientAuditDetails!.createdTime <
                 endOfDay.millisecondsSinceEpoch)
         .toList();
 

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory_management/view_record_lga.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory_management/view_record_lga.dart
@@ -1,4 +1,5 @@
-import 'package:auto_route/auto_route.dart';
+import 'package:collection/collection.dart';
+import 'package:digit_components/widgets/atoms/digit_toaster.dart';
 import 'package:digit_data_model/data_model.dart';
 import 'package:digit_ui_components/digit_components.dart';
 import 'package:digit_ui_components/widgets/atoms/input_wrapper.dart';
@@ -10,16 +11,16 @@ import 'package:inventory_management/models/entities/stock.dart';
 import 'package:inventory_management/models/entities/transaction_reason.dart';
 import 'package:inventory_management/models/entities/transaction_type.dart';
 import 'package:inventory_management/utils/i18_key_constants.dart' as i18;
+import 'package:inventory_management/utils/typedefs.dart';
 import 'package:inventory_management/utils/utils.dart';
-import 'package:registration_delivery/widgets/localized.dart';
 import 'package:reactive_forms/reactive_forms.dart';
+import 'package:registration_delivery/widgets/localized.dart';
 
 import '../../blocs/auth/auth.dart';
 import '../../router/app_router.dart';
 import '../../utils/constants.dart';
 import '../../utils/extensions/extensions.dart';
-import 'package:collection/collection.dart';
-
+import '../../utils/i18_key_constants.dart' as i18_local;
 import '../../widgets/custom_back_navigation.dart';
 
 @RoutePage()
@@ -124,9 +125,86 @@ class _ViewStockRecordsLGAPageState
     super.dispose();
   }
 
+  num _getQuantityCount(Iterable<StockModel> stocks) {
+    return stocks.fold<num>(
+      0.0,
+      (old, e) => (num.tryParse(e.quantity ?? '') ?? 0.0) + old,
+    );
+  }
+
+  Future<num> getQuantityReceivedToday(
+      BuildContext context, StockModel stock) async {
+    final StockDataRepository stockRepository =
+        context.repository<StockModel, StockSearchModel>();
+    final productVariantId = stock.productVariantId;
+    final facilityId;
+    if (InventorySingleton().isDistributor) {
+      facilityId = InventorySingleton().loggedInUserUuid;
+    } else {
+      facilityId = stock.receiverId;
+    }
+
+    if ((productVariantId == null) || facilityId == null) return 0;
+
+    final now = DateTime.now();
+    final startOfDay = DateTime(now.year, now.month, now.day);
+    final endOfDay = startOfDay.add(const Duration(days: 1));
+
+    // Fetching the stock receipt details for today
+    final receivedStocks = (await stockRepository.search(
+      StockSearchModel(
+          productVariantId: productVariantId,
+          receiverId: facilityId,
+          transactionType: [TransactionType.received.toValue()]),
+    ))
+        .where((element) =>
+            element.auditDetails != null &&
+            element.auditDetails?.createdBy ==
+                InventorySingleton().loggedInUserUuid &&
+            element.clientAuditDetails?.createdTime != null &&
+            element.clientAuditDetails!.createdTime >=
+                startOfDay.millisecondsSinceEpoch &&
+            element.clientAuditDetails!.createdTime <=
+                endOfDay.millisecondsSinceEpoch)
+        .toList();
+
+    return _getQuantityCount(
+      receivedStocks.where((e) =>
+          e.transactionType == TransactionType.received.toValue() &&
+          e.transactionReason == TransactionReason.received.toValue()),
+    );
+  }
+
   Future<void> _handleSubmission() async {
     if (_form.valid && !isSubmitClicked) {
       isSubmitClicked = true;
+      final theme = Theme.of(context);
+
+      for (final stock in widget.stockRecords) {
+        final quantityReceivedToday =
+            await getQuantityReceivedToday(context, stock);
+
+        final quantity =
+            int.parse(_form.control('quantityReceived').value.toString());
+
+        if (stock.transactionType == TransactionType.dispatched.toValue() &&
+            context.isCommunityDistributor) {
+          if (quantity + quantityReceivedToday >
+              Constants.cddStockTransactionDailyLimit) {
+            await DigitToast.show(
+              context,
+              options: DigitToastOptions(
+                  localizations.translate(i18_local
+                      .stockDetails.stockReceivedByCddDailyLimitValidation),
+                  true,
+                  theme),
+            );
+            isSubmitClicked = false;
+            return;
+          }
+        }
+      }
+
       final updatedStocks = widget.stockRecords.map((stock) {
         final additionalFields = stock.additionalFields?.fields ?? [];
 

--- a/apps/health_campaign_field_worker_app/lib/pages/inventory_management/view_record_lga.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/inventory_management/view_record_lga.dart
@@ -187,22 +187,22 @@ class _ViewStockRecordsLGAPageState
         final quantity =
             int.parse(_form.control('quantityReceived').value.toString());
 
-        if (stock.transactionType == TransactionType.dispatched.toValue() &&
-            context.isCommunityDistributor) {
-          if (quantity + quantityReceivedToday >
-              Constants.cddStockTransactionDailyLimit) {
-            await DigitToast.show(
-              context,
-              options: DigitToastOptions(
-                  localizations.translate(i18_local
-                      .stockDetails.stockReceivedByCddDailyLimitValidation),
-                  true,
-                  theme),
-            );
-            isSubmitClicked = false;
-            return;
-          }
-        }
+        // if (stock.transactionType == TransactionType.dispatched.toValue() &&
+        //     context.isCommunityDistributor) {
+        //   if (quantity + quantityReceivedToday >
+        //       Constants.cddStockTransactionDailyLimit) {
+        //     await DigitToast.show(
+        //       context,
+        //       options: DigitToastOptions(
+        //           localizations.translate(i18_local
+        //               .stockDetails.stockReceivedByCddDailyLimitValidation),
+        //           true,
+        //           theme),
+        //     );
+        //     isSubmitClicked = false;
+        //     return;
+        //   }
+        // }
       }
 
       final updatedStocks = widget.stockRecords.map((stock) {

--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_search_beneficiary.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_search_beneficiary.dart
@@ -12,6 +12,7 @@ import 'package:digit_ui_components/widgets/atoms/switch.dart';
 import 'package:digit_ui_components/widgets/molecules/digit_card.dart';
 import 'package:digit_ui_components/widgets/molecules/show_pop_up.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:registration_delivery/blocs/search_households/search_bloc_common_wrapper.dart';
@@ -167,7 +168,10 @@ class _CustomSearchBeneficiaryPageState
                                       inputFormatters:
                                           isSearchByBeneficaryIdEnabled
                                               ? [BeneficiaryIdInputFormatter()]
-                                              : [],
+                                              : [
+                                                  FilteringTextInputFormatter
+                                                      .deny(RegExp(r'[0-9]'))
+                                                ],
                                       hintText: (RegistrationDeliverySingleton()
                                                   .householdType ==
                                               HouseholdType.community)

--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_search_beneficiary.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_search_beneficiary.dart
@@ -457,12 +457,46 @@ class _CustomSearchBeneficiaryPageState
                     },
                     child: BlocBuilder<LocationBloc, LocationState>(
                       builder: (context, locationState) {
+                        final List<HouseholdMemberWrapper>
+                            sortedHouseholdMembers =
+                            List<HouseholdMemberWrapper>.from(
+                                searchHouseholdsState.householdMembers);
+
+                        if (isProximityEnabled && lat != 0.0 && long != 0.0) {
+                          sortedHouseholdMembers.sort((a, b) {
+                            final distanceA = calculateDistance(
+                                  Coordinate(
+                                    lat,
+                                    long,
+                                  ),
+                                  Coordinate(
+                                    a.household?.address?.latitude,
+                                    a.household?.address?.longitude,
+                                  ),
+                                ) ??
+                                double.infinity;
+
+                            final distanceB = calculateDistance(
+                                  Coordinate(
+                                    lat,
+                                    long,
+                                  ),
+                                  Coordinate(
+                                    b.household?.address?.latitude,
+                                    b.household?.address?.longitude,
+                                  ),
+                                ) ??
+                                double.infinity;
+
+                            return distanceA.compareTo(distanceB);
+                          });
+                        }
+
                         return SliverList(
                           delegate: SliverChildBuilderDelegate(
                             (ctx, index) {
-                              HouseholdMemberWrapper i = searchHouseholdsState
-                                  .householdMembers
-                                  .elementAt(index);
+                              HouseholdMemberWrapper i =
+                                  sortedHouseholdMembers.elementAt(index);
                               registration_delivery.HouseholdMemberWrapper
                                   householdMemberWrapper =
                                   registration_delivery.HouseholdMemberWrapper(
@@ -566,8 +600,7 @@ class _CustomSearchBeneficiaryPageState
                                 ),
                               );
                             },
-                            childCount:
-                                searchHouseholdsState.householdMembers.length,
+                            childCount: sortedHouseholdMembers.length,
                           ),
                         );
                       },
@@ -720,8 +753,13 @@ class _CustomSearchBeneficiaryPageState
                       mainAxisSize: MainAxisSize.max,
                       type: DigitButtonType.primary,
                       size: DigitButtonSize.large,
-                      isDisabled: !(isSearchByBeneficaryIdEnabled &&
-                          beneficiaryIdSearchResultsNotFound),
+                      isDisabled: !(
+                          // No results in normal search mode
+                          (!isSearchByBeneficaryIdEnabled &&
+                                  searchHouseholdsState.resultsNotFound) ||
+                              // No results in beneficiary ID search mode
+                              (isSearchByBeneficaryIdEnabled &&
+                                  beneficiaryIdSearchResultsNotFound)),
                       onPressed: () {
                         int spaq1 = context.spaq1;
 

--- a/apps/health_campaign_field_worker_app/lib/utils/constants.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/constants.dart
@@ -116,7 +116,7 @@ class Constants {
   static const String blueVAS = "Blue VAS";
   static const String redVAS = "Red VAS";
 
-  static const int cddStockTransactionDailyLimit = 20;
+  // static const int cddStockTransactionDailyLimit = 20;
 
   static const String height = "height";
   static const String weight = "weight";

--- a/apps/health_campaign_field_worker_app/lib/utils/constants.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/constants.dart
@@ -116,6 +116,8 @@ class Constants {
   static const String blueVAS = "Blue VAS";
   static const String redVAS = "Red VAS";
 
+  static const int cddStockTransactionDailyLimit = 20;
+
   static const String height = "height";
   static const String weight = "weight";
 

--- a/apps/health_campaign_field_worker_app/lib/utils/i18_key_constants.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/i18_key_constants.dart
@@ -511,6 +511,13 @@ class HomeShowcase {
 
 class StockDetails {
   const StockDetails();
+
+  String get stockDispatchToCddDailyLimitValidation =>
+      'STOCK_DISPATCH_TO_CDD_DAILY_LIMIT_VALIDATION';
+
+  String get stockReceivedByCddDailyLimitValidation =>
+      'STOCK_RECEIVE_BY_CDD_DAILY_LIMIT_VALIDATION';
+
   String get selectTransactingPartyReturnedFrom =>
       'STOCK_DETAILS_RETURNED_FROM';
 

--- a/apps/health_campaign_field_worker_app/lib/utils/registration_delivery/utils_smc.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/registration_delivery/utils_smc.dart
@@ -557,10 +557,11 @@ DeliveryDoseCriteria? fetchProductVariant(ProjectCycleDelivery? currentDelivery,
             individualModel.additionalFields!.fields
                 .where((element) => element.key == Constants.height)
                 .isNotEmpty) {
-          height = int.parse(individualModel.additionalFields!.fields
+          height = int.tryParse(individualModel.additionalFields!.fields
                   .where((element) => element.key == Constants.height)
-                  .first
-                  .value ??
+                  .firstOrNull
+                  ?.value
+                  .toString() ??
               '0');
         }
       }

--- a/apps/health_campaign_field_worker_app/pubspec.yaml
+++ b/apps/health_campaign_field_worker_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_campaign_field_worker_app
 description: A new Flutter project.
 publish_to: "none"
-version: 1.8.94
+version: 1.8.95
 
 environment:
   sdk: ">=3.3.0 <=4.0.0"

--- a/apps/health_campaign_field_worker_app/pubspec.yaml
+++ b/apps/health_campaign_field_worker_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_campaign_field_worker_app
 description: A new Flutter project.
 publish_to: "none"
-version: 1.8.93
+version: 1.8.94
 
 environment:
   sdk: ">=3.3.0 <=4.0.0"

--- a/apps/health_campaign_field_worker_app/pubspec.yaml
+++ b/apps/health_campaign_field_worker_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_campaign_field_worker_app
 description: A new Flutter project.
 publish_to: "none"
-version: 1.8.96
+version: 1.8.97
 
 environment:
   sdk: ">=3.3.0 <=4.0.0"

--- a/apps/health_campaign_field_worker_app/pubspec.yaml
+++ b/apps/health_campaign_field_worker_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_campaign_field_worker_app
 description: A new Flutter project.
 publish_to: "none"
-version: 1.8.95
+version: 1.8.96
 
 environment:
   sdk: ">=3.3.0 <=4.0.0"

--- a/apps/health_campaign_field_worker_app/pubspec.yaml
+++ b/apps/health_campaign_field_worker_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_campaign_field_worker_app
 description: A new Flutter project.
 publish_to: "none"
-version: 1.8.91
+version: 1.8.93
 
 environment:
   sdk: ">=3.3.0 <=4.0.0"


### PR DESCRIPTION
- Fixed beneficiary registration search button enable/disable logic. 
- Implemented distance-based sorting for proximity search results. 
- Added an input formatter to prevent numeric input for beneficiary/head name search fields. 
- Added daily stock transaction limit validation for CDD stock receipt and HF stock dispatch. 
- Fixed summary report “no data available” issue when task status is null.
- Resolved height parsing bug in fetchProductVariant. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distance-based sorting for beneficiary search results when proximity is enabled.

* **Bug Fixes**
  * Ignore tasks with null status in administered checks.
  * Prevent digits in non-ID beneficiary searches.
  * Safer parsing for missing/invalid height values.

* **Chores**
  * App version bumped to 1.8.97.
  * Crashlytics enabled and Firebase project/config updated.
  * Added daily-limit translation keys and helpers for daily-issue checks (validation currently inactive).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->