### PR TITLE
fix report issue for loss and damage in dispatch

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
@@ -76,8 +76,8 @@ class CustomInventoryReportBloc
           TransactionReason.damagedInStorage.toValue(),
           TransactionReason.damagedInTransit.toValue(),
         ];
-        receiverId = facilityId;
-        senderId = null;
+        receiverId = null;
+        senderId = facilityId;
       } else if (reportType == CustomInventoryReport.loss) {
         transactionType = [TransactionType.dispatched.toValue()];
         transactionReason = [

--- a/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
@@ -43,7 +43,7 @@ class CustomInventoryReportBloc
     if (facilityId.trim().isEmpty || productVariantId.trim().isEmpty) {
       emit(const InventoryReportEmptyState());
     } else {
-      if (reportType == InventoryReportType.reconciliation) {
+      if (reportType == CustomInventoryReport.reconciliation) {
         throw AppException(
           'Invalid report type: ${event.reportType}',
         );
@@ -55,30 +55,30 @@ class CustomInventoryReportBloc
       String? senderId;
       String? receiverId;
 
-      if (reportType == InventoryReportType.receipt) {
+      if (reportType == CustomInventoryReport.receipt) {
         transactionType = [TransactionType.received.toValue()];
         transactionReason = [TransactionReason.received.toValue()];
         receiverId = facilityId;
         senderId = null;
-      } else if (reportType == InventoryReportType.dispatch) {
+      } else if (reportType == CustomInventoryReport.dispatch) {
         transactionType = [TransactionType.dispatched.toValue()];
         transactionReason = [];
         receiverId = null;
         senderId = facilityId;
-      } else if (reportType == InventoryReportType.returned) {
+      } else if (reportType == CustomInventoryReport.returned) {
         transactionType = [TransactionType.received.toValue()];
         transactionReason = [TransactionReason.returned.toValue()];
         receiverId = facilityId;
         senderId = null;
-      } else if (reportType == InventoryReportType.damage) {
+      } else if (reportType == CustomInventoryReport.damage) {
         transactionType = [TransactionType.dispatched.toValue()];
         transactionReason = [
           TransactionReason.damagedInStorage.toValue(),
           TransactionReason.damagedInTransit.toValue(),
         ];
-        receiverId = null;
-        senderId = facilityId;
-      } else if (reportType == InventoryReportType.loss) {
+        receiverId = facilityId;
+        senderId = null;
+      } else if (reportType == CustomInventoryReport.loss) {
         transactionType = [TransactionType.dispatched.toValue()];
         transactionReason = [
           TransactionReason.lostInStorage.toValue(),
@@ -114,7 +114,7 @@ class CustomInventoryReportBloc
       // Added data filter for dispatch because of no transaction reasons
       // We are removing all the loss and damage stocks from here
       var newData = data;
-      if (reportType == InventoryReportType.dispatch && data.isNotEmpty) {
+      if (reportType == CustomInventoryReport.dispatch && data.isNotEmpty) {
         newData = data.where((e) {
           return [
                 TransactionReason.damagedInStorage.toValue(),
@@ -173,7 +173,7 @@ class CustomInventoryReportBloc
 @freezed
 class InventoryReportEvent with _$InventoryReportEvent {
   const factory InventoryReportEvent.loadStockData({
-    required InventoryReportType reportType,
+    required CustomInventoryReport reportType,
     required String facilityId,
     required String productVariantId,
   }) = InventoryReportLoadStockDataEvent;
@@ -198,4 +198,13 @@ class InventoryReportState with _$InventoryReportState {
   const factory InventoryReportState.stockReconciliation({
     @Default({}) Map<String, List<StockReconciliationModel>> data,
   }) = InventoryReportStockReconciliationState;
+}
+
+enum CustomInventoryReport {
+  receipt,
+  dispatch,
+  returned,
+  damage,
+  loss,
+  reconciliation,
 }

--- a/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
@@ -5,6 +5,7 @@ import 'package:digit_data_model/utils/app_exception.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:intl/intl.dart';
+import 'package:inventory_management/blocs/inventory_report.dart';
 import 'package:inventory_management/utils/utils.dart';
 
 import 'package:inventory_management/utils/typedefs.dart';
@@ -197,13 +198,4 @@ class InventoryReportState with _$InventoryReportState {
   const factory InventoryReportState.stockReconciliation({
     @Default({}) Map<String, List<StockReconciliationModel>> data,
   }) = InventoryReportStockReconciliationState;
-}
-
-enum InventoryReportType {
-  receipt,
-  dispatch,
-  returned,
-  damage,
-  loss,
-  reconciliation,
 }

--- a/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.dart
@@ -76,16 +76,16 @@ class CustomInventoryReportBloc
           TransactionReason.damagedInStorage.toValue(),
           TransactionReason.damagedInTransit.toValue(),
         ];
-        receiverId = facilityId;
-        senderId = null;
+        receiverId = null;
+        senderId = facilityId;
       } else if (reportType == InventoryReportType.loss) {
         transactionType = [TransactionType.dispatched.toValue()];
         transactionReason = [
           TransactionReason.lostInStorage.toValue(),
           TransactionReason.lostInTransit.toValue(),
         ];
-        receiverId = facilityId;
-        senderId = null;
+        receiverId = null;
+        senderId = facilityId;
       }
       final data = (receiverId != null
               ? await stockRepository.search(

--- a/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.freezed.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/inventory_management/custom_inventory_report.freezed.dart
@@ -18,8 +18,8 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$InventoryReportEvent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(InventoryReportType reportType, String facilityId,
-            String productVariantId)
+    required TResult Function(CustomInventoryReport reportType,
+            String facilityId, String productVariantId)
         loadStockData,
     required TResult Function(String facilityId, String productVariantId)
         loadStockReconciliationData,
@@ -28,7 +28,7 @@ mixin _$InventoryReportEvent {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(InventoryReportType reportType, String facilityId,
+    TResult? Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult? Function(String facilityId, String productVariantId)?
@@ -38,7 +38,7 @@ mixin _$InventoryReportEvent {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(InventoryReportType reportType, String facilityId,
+    TResult Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult Function(String facilityId, String productVariantId)?
@@ -103,7 +103,7 @@ abstract class _$$InventoryReportLoadStockDataEventImplCopyWith<$Res> {
       __$$InventoryReportLoadStockDataEventImplCopyWithImpl<$Res>;
   @useResult
   $Res call(
-      {InventoryReportType reportType,
+      {CustomInventoryReport reportType,
       String facilityId,
       String productVariantId});
 }
@@ -129,7 +129,7 @@ class __$$InventoryReportLoadStockDataEventImplCopyWithImpl<$Res>
       reportType: null == reportType
           ? _value.reportType
           : reportType // ignore: cast_nullable_to_non_nullable
-              as InventoryReportType,
+              as CustomInventoryReport,
       facilityId: null == facilityId
           ? _value.facilityId
           : facilityId // ignore: cast_nullable_to_non_nullable
@@ -152,7 +152,7 @@ class _$InventoryReportLoadStockDataEventImpl
       required this.productVariantId});
 
   @override
-  final InventoryReportType reportType;
+  final CustomInventoryReport reportType;
   @override
   final String facilityId;
   @override
@@ -191,8 +191,8 @@ class _$InventoryReportLoadStockDataEventImpl
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(InventoryReportType reportType, String facilityId,
-            String productVariantId)
+    required TResult Function(CustomInventoryReport reportType,
+            String facilityId, String productVariantId)
         loadStockData,
     required TResult Function(String facilityId, String productVariantId)
         loadStockReconciliationData,
@@ -204,7 +204,7 @@ class _$InventoryReportLoadStockDataEventImpl
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(InventoryReportType reportType, String facilityId,
+    TResult? Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult? Function(String facilityId, String productVariantId)?
@@ -217,7 +217,7 @@ class _$InventoryReportLoadStockDataEventImpl
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(InventoryReportType reportType, String facilityId,
+    TResult Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult Function(String facilityId, String productVariantId)?
@@ -274,12 +274,12 @@ class _$InventoryReportLoadStockDataEventImpl
 abstract class InventoryReportLoadStockDataEvent
     implements InventoryReportEvent {
   const factory InventoryReportLoadStockDataEvent(
-          {required final InventoryReportType reportType,
+          {required final CustomInventoryReport reportType,
           required final String facilityId,
           required final String productVariantId}) =
       _$InventoryReportLoadStockDataEventImpl;
 
-  InventoryReportType get reportType;
+  CustomInventoryReport get reportType;
   String get facilityId;
   String get productVariantId;
   @JsonKey(ignore: true)
@@ -375,8 +375,8 @@ class _$InventoryReportLoadStockReconciliationDataEventImpl
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(InventoryReportType reportType, String facilityId,
-            String productVariantId)
+    required TResult Function(CustomInventoryReport reportType,
+            String facilityId, String productVariantId)
         loadStockData,
     required TResult Function(String facilityId, String productVariantId)
         loadStockReconciliationData,
@@ -388,7 +388,7 @@ class _$InventoryReportLoadStockReconciliationDataEventImpl
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(InventoryReportType reportType, String facilityId,
+    TResult? Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult? Function(String facilityId, String productVariantId)?
@@ -401,7 +401,7 @@ class _$InventoryReportLoadStockReconciliationDataEventImpl
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(InventoryReportType reportType, String facilityId,
+    TResult Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult Function(String facilityId, String productVariantId)?
@@ -512,8 +512,8 @@ class _$InventoryReportLoadingEventImpl implements InventoryReportLoadingEvent {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(InventoryReportType reportType, String facilityId,
-            String productVariantId)
+    required TResult Function(CustomInventoryReport reportType,
+            String facilityId, String productVariantId)
         loadStockData,
     required TResult Function(String facilityId, String productVariantId)
         loadStockReconciliationData,
@@ -525,7 +525,7 @@ class _$InventoryReportLoadingEventImpl implements InventoryReportLoadingEvent {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(InventoryReportType reportType, String facilityId,
+    TResult? Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult? Function(String facilityId, String productVariantId)?
@@ -538,7 +538,7 @@ class _$InventoryReportLoadingEventImpl implements InventoryReportLoadingEvent {
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(InventoryReportType reportType, String facilityId,
+    TResult Function(CustomInventoryReport reportType, String facilityId,
             String productVariantId)?
         loadStockData,
     TResult Function(String facilityId, String productVariantId)?

--- a/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
@@ -502,7 +502,7 @@ class CustomInventoryReportDetailsPageState
                                                                     widget.reportType ==
                                                                         CustomInventoryReport
                                                                             .damage
-                                                                ? model.senderType ==
+                                                                ? model.receiverType ==
                                                                         "STAFF"
                                                                     ? localizations.translate(
                                                                         (model.additionalFields?.fields.firstWhereOrNull((e) => e.key == Constants.teamNameDeliveryTeam)?.value ??

--- a/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
@@ -7,6 +7,8 @@ import 'package:digit_ui_components/widgets/atoms/input_wrapper.dart';
 import 'package:digit_ui_components/widgets/molecules/digit_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:inventory_management/blocs/inventory_report.dart'
+    show InventoryReportType;
 import 'package:inventory_management/router/inventory_router.gm.dart';
 import 'package:inventory_management/utils/extensions/extensions.dart';
 import 'package:reactive_forms/reactive_forms.dart';

--- a/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
@@ -27,6 +27,7 @@ import 'package:inventory_management/utils/utils.dart';
 import 'package:inventory_management/widgets/back_navigation_help_header.dart';
 
 import '../../../blocs/inventory_management/custom_inventory_report.dart';
+import '../../../utils/constants.dart';
 
 @RoutePage()
 class CustomInventoryReportDetailsPage extends LocalizedStatefulWidget {
@@ -491,10 +492,7 @@ class CustomInventoryReportDetailsPageState
                                                           DigitGridCell(
                                                             key:
                                                                 transactingPartyKey,
-                                                            value: widget
-                                                                            .reportType ==
-                                                                        CustomInventoryReport
-                                                                            .receipt ||
+                                                            value: widget.reportType == CustomInventoryReport.receipt ||
                                                                     widget.reportType ==
                                                                         CustomInventoryReport
                                                                             .dispatch ||
@@ -504,17 +502,25 @@ class CustomInventoryReportDetailsPageState
                                                                     widget.reportType ==
                                                                         CustomInventoryReport
                                                                             .damage
-                                                                ? localizations
-                                                                    .translate(
+                                                                ? model.senderType ==
+                                                                        "STAFF"
+                                                                    ? localizations.translate(
+                                                                        (model.additionalFields?.fields.firstWhereOrNull((e) => e.key == Constants.teamNameDeliveryTeam)?.value ??
+                                                                            'Delivery Team'))
+                                                                    : localizations.translate(
                                                                         'FAC_${model.receiverId}' ??
                                                                             model
                                                                                 .receiverType ??
                                                                             '')
-                                                                : localizations
-                                                                    .translate(
-                                                                        'FAC_${model.senderId}' ??
-                                                                            model.receiverType ??
-                                                                            ''),
+                                                                : model.senderType ==
+                                                                        "STAFF"
+                                                                    ? localizations.translate((model
+                                                                            .additionalFields
+                                                                            ?.fields
+                                                                            .firstWhereOrNull((e) => e.key == Constants.teamNameDeliveryTeam)
+                                                                            ?.value ??
+                                                                        'Delivery Team'))
+                                                                    : localizations.translate('FAC_${model.senderId}' ?? model.receiverType ?? ''),
                                                           ),
                                                         ],
                                                       ),

--- a/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
@@ -7,6 +7,7 @@ import 'package:digit_ui_components/widgets/atoms/input_wrapper.dart';
 import 'package:digit_ui_components/widgets/molecules/digit_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:inventory_management/blocs/app_localization.dart';
 import 'package:inventory_management/blocs/inventory_report.dart'
     show InventoryReportType;
 import 'package:inventory_management/router/inventory_router.gm.dart';
@@ -27,6 +28,7 @@ import 'package:inventory_management/utils/utils.dart';
 import 'package:inventory_management/widgets/back_navigation_help_header.dart';
 
 import '../../../blocs/inventory_management/custom_inventory_report.dart';
+import '../../../blocs/localization/app_localization.dart';
 import '../../../utils/constants.dart';
 
 @RoutePage()
@@ -492,7 +494,10 @@ class CustomInventoryReportDetailsPageState
                                                           DigitGridCell(
                                                             key:
                                                                 transactingPartyKey,
-                                                            value: widget.reportType == CustomInventoryReport.receipt ||
+                                                            value: widget
+                                                                            .reportType ==
+                                                                        CustomInventoryReport
+                                                                            .receipt ||
                                                                     widget.reportType ==
                                                                         CustomInventoryReport
                                                                             .dispatch ||
@@ -502,25 +507,20 @@ class CustomInventoryReportDetailsPageState
                                                                     widget.reportType ==
                                                                         CustomInventoryReport
                                                                             .damage
-                                                                ? model.receiverType ==
-                                                                        "STAFF"
-                                                                    ? localizations.translate(
-                                                                        (model.additionalFields?.fields.firstWhereOrNull((e) => e.key == Constants.teamNameDeliveryTeam)?.value ??
-                                                                            'Delivery Team'))
-                                                                    : localizations.translate(
-                                                                        'FAC_${model.receiverId}' ??
-                                                                            model
-                                                                                .receiverType ??
-                                                                            '')
-                                                                : model.senderType ==
-                                                                        "STAFF"
-                                                                    ? localizations.translate((model
-                                                                            .additionalFields
-                                                                            ?.fields
-                                                                            .firstWhereOrNull((e) => e.key == Constants.teamNameDeliveryTeam)
-                                                                            ?.value ??
-                                                                        'Delivery Team'))
-                                                                    : localizations.translate('FAC_${model.senderId}' ?? model.receiverType ?? ''),
+                                                                ? _buildTransactingPartyLabel(
+                                                                    localizations,
+                                                                    isReceiver:
+                                                                        true,
+                                                                    model:
+                                                                        model,
+                                                                  )
+                                                                : _buildTransactingPartyLabel(
+                                                                    localizations,
+                                                                    isReceiver:
+                                                                        false,
+                                                                    model:
+                                                                        model,
+                                                                  ),
                                                           ),
                                                         ],
                                                       ),
@@ -825,6 +825,53 @@ class CustomInventoryReportDetailsPageState
       return '0';
     }
     return (double.tryParse(count.value.toString()) ?? 0.0).toStringAsFixed(0);
+  }
+
+  /// Builds a transacting party label (sender or receiver) with proper null checks.
+  ///
+  /// This method conditionally builds the translation key based on the model's
+  /// sender/receiver ID and type, ensuring that null IDs don't produce strings
+  /// like "FAC_null". It properly handles STAFF types and falls back to the
+  /// appropriate type when ID is null.
+  ///
+  /// @param localizations The localization instance for translating keys
+  /// @param isReceiver Whether to build the receiver label (true) or sender label (false)
+  /// @param model The stock model containing sender/receiver information
+  /// @return The translated party label
+  String _buildTransactingPartyLabel(
+    InventoryLocalization localizations, {
+    required bool isReceiver,
+    required StockModel model,
+  }) {
+    String key;
+
+    if (isReceiver) {
+      if (model.receiverType == "STAFF") {
+        key = model.additionalFields?.fields
+                .firstWhereOrNull(
+                    (e) => e.key == Constants.teamNameDeliveryTeam)
+                ?.value ??
+            'Delivery Team';
+      } else if (model.receiverId != null && model.receiverId!.isNotEmpty) {
+        key = 'FAC_${model.receiverId}';
+      } else {
+        key = model.receiverType ?? '';
+      }
+    } else {
+      if (model.senderType == "STAFF") {
+        key = model.additionalFields?.fields
+                .firstWhereOrNull(
+                    (e) => e.key == Constants.teamNameDeliveryTeam)
+                ?.value ??
+            'Delivery Team';
+      } else if (model.senderId != null && model.senderId!.isNotEmpty) {
+        key = 'FAC_${model.senderId}';
+      } else {
+        key = model.senderType ?? '';
+      }
+    }
+
+    return key.isEmpty ? '' : localizations.translate(key);
   }
 
   handleFacilitySelection(

--- a/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_report_details.dart
@@ -504,14 +504,17 @@ class CustomInventoryReportDetailsPageState
                                                                     widget.reportType ==
                                                                         InventoryReportType
                                                                             .damage
-                                                                ? model.receiverId ??
-                                                                    model
-                                                                        .receiverType ??
-                                                                    ''
-                                                                : model.senderId ??
-                                                                    model
-                                                                        .receiverType ??
-                                                                    '',
+                                                                ? localizations
+                                                                    .translate(
+                                                                        'FAC_${model.receiverId}' ??
+                                                                            model
+                                                                                .receiverType ??
+                                                                            '')
+                                                                : localizations
+                                                                    .translate(
+                                                                        'FAC_${model.senderId}' ??
+                                                                            model.receiverType ??
+                                                                            ''),
                                                           ),
                                                         ],
                                                       ),

--- a/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_stock_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_stock_details.dart
@@ -552,7 +552,7 @@ class CustomStockDetailsPageState
                                                         if (scannerState
                                                             .barCodes
                                                             .isNotEmpty)
-                                                          addBarCodesToFields(
+                                                          ...addBarCodesToFields(
                                                               scannerState
                                                                   .barCodes),
                                                       ],
@@ -1456,15 +1456,20 @@ class CustomStockDetailsPageState
   ///
   /// @param barCodes The list of GS1Barcode objects to be processed.
   /// @return A map where the keys and values are joined by '|'.
-  AdditionalField addBarCodesToFields(List<GS1Barcode> barCodes) {
-    List<String> keys = [];
-    List<String> values = [];
+  List<AdditionalField> addBarCodesToFields(List<GS1Barcode> barCodes) {
+    List<AdditionalField> additionalFields = [];
     for (var element in barCodes) {
+      List<String> keys = [];
+      List<String> values = [];
       for (var e in element.elements.entries) {
-        keys.add(e.key.toString());
-        values.add(e.value.data.toString());
+        String key = e.key.toString();
+        if (key == "10" || key == "21" || key == "17") {
+          keys.add(key);
+          values.add(e.value.data.toString());
+        }
       }
+      additionalFields.add(AdditionalField(keys.join('|'), values.join('|')));
     }
-    return AdditionalField(keys.join('|'), values.join('|'));
+    return additionalFields;
   }
 }

--- a/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_stock_details.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/reports/inventory_management/custom_stock_details.dart
@@ -24,8 +24,10 @@ import 'package:inventory_management/widgets/localized.dart';
 import 'package:inventory_management/blocs/product_variant.dart';
 import 'package:inventory_management/blocs/record_stock.dart';
 import 'package:inventory_management/widgets/back_navigation_help_header.dart';
+import 'package:survey_form/utils/constants.dart';
 
 import '../../../utils/i18_key_constants.dart' as i18_local;
+import '../../../utils/constants.dart' as local_constants;
 
 @RoutePage()
 class CustomStockDetailsPage extends LocalizedStatefulWidget {
@@ -60,6 +62,7 @@ class CustomStockDetailsPageState
   List<String> commentsOptions = [];
 
   String? teamCode;
+  String? teamName;
   List<GS1Barcode> balesCode = [];
 
   FormGroup _form(StockRecordEntryType stockType) {
@@ -207,6 +210,9 @@ class CustomStockDetailsPageState
                       listener: (context, scannerState) {
                         teamCode = scannerState.qrCodes.isNotEmpty
                             ? scannerState.qrCodes.last.split("||").last
+                            : null;
+                        teamName = scannerState.qrCodes.isNotEmpty
+                            ? scannerState.qrCodes.last.split("||").first
                             : null;
 
                         balesCode = scannerState.barCodes;
@@ -518,6 +524,16 @@ class CustomStockDetailsPageState
                                                           AdditionalField(
                                                             'deliveryTeam',
                                                             deliveryTeamName,
+                                                          ),
+                                                        if (deliveryTeamSelected &&
+                                                            (teamName ?? '')
+                                                                .trim()
+                                                                .isNotEmpty)
+                                                          AdditionalField(
+                                                            local_constants
+                                                                .Constants
+                                                                .teamNameDeliveryTeam,
+                                                            teamName,
                                                           ),
                                                         if (hasLocationData) ...[
                                                           AdditionalField(

--- a/apps/health_campaign_field_worker_app/lib/utils/constants.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/constants.dart
@@ -113,6 +113,7 @@ class Constants {
   static const String household = 'Household';
   static const String projectBeneficiary = 'ProjectBeneficiary';
   static const String bednetDistributed = 'BednetDistributed';
+  static const String teamNameDeliveryTeam = 'teamName';
 
   static const int targetHouseHold = 200;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture delivery team name from QR scans and show it in stock delivery details.
  * Added a constant key for the delivery team name.

* **Bug Fixes**
  * Transacting party labels now show localized facility names or delivery team names for receipt/dispatch/loss/damage.
  * Loss reports now use the corrected sender/receiver direction consistent with damage reports.

* **Refactor**
  * Barcode data emitted as separate additional fields (one per barcode) and limited to core GS1 keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->