### PR TITLE
minimum 3 characters on address validation

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_household_location.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_household_location.dart
@@ -552,22 +552,26 @@ class CustomHouseholdLocationPageState
       _addressLine1Key:
           FormControl<String>(value: addressModel?.addressLine1, validators: [
         Validators.maxLength(64),
+        Validators.minLength(3),
       ]),
       _addressLine2Key: FormControl<String>(
         value: addressModel?.addressLine2,
         validators: [
           Validators.maxLength(64),
+          Validators.minLength(3),
         ],
       ),
       _landmarkKey:
           FormControl<String>(value: addressModel?.landmark, validators: [
         Validators.maxLength(64),
+        Validators.minLength(3),
         Validators.delegate((validator) =>
             local_utils.CustomValidator.onlyAlphabetsAndDigits(validator)),
       ]),
       _postalCodeKey:
           FormControl<String>(value: addressModel?.pincode, validators: [
         Validators.maxLength(6),
+        Validators.minLength(3),
       ]),
       _latKey: FormControl<double>(value: addressModel?.latitude),
       _lngKey: FormControl<double>(

--- a/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_household_location.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/registration_delivery/custom_household_location.dart
@@ -383,7 +383,7 @@ class CustomHouseholdLocationPageState
                               'required': (_) => localizations.translate(
                                     i18.common.corecommonRequired,
                                   ),
-                              'sizeLessThan2': (_) => localizations
+                              'minLength': (_) => localizations
                                   .translate(i18.common.min3CharsRequired),
                               'maxLength': (object) => localizations
                                   .translate(i18.common.maxCharsRequired)
@@ -412,7 +412,7 @@ class CustomHouseholdLocationPageState
                               'required': (_) => localizations.translate(
                                     i18.common.corecommonRequired,
                                   ),
-                              'sizeLessThan2': (_) => localizations
+                              'minLength': (_) => localizations
                                   .translate(i18.common.min3CharsRequired),
                               'maxLength': (object) => localizations
                                   .translate(i18.common.maxCharsRequired)
@@ -441,7 +441,7 @@ class CustomHouseholdLocationPageState
                                   'required': (_) => localizations.translate(
                                         i18.common.corecommonRequired,
                                       ),
-                                  'sizeLessThan2': (_) => localizations
+                                  'minLength': (_) => localizations
                                       .translate(i18.common.min3CharsRequired),
                                   'maxLength': (object) => localizations
                                       .translate(i18.common.maxCharsRequired)
@@ -467,7 +467,7 @@ class CustomHouseholdLocationPageState
                                   'required': (_) => localizations.translate(
                                         i18.common.corecommonRequired,
                                       ),
-                                  'sizeLessThan2': (_) => localizations
+                                  'minLength': (_) => localizations
                                       .translate(i18.common.min3CharsRequired),
                                   'maxLength': (object) => localizations
                                       .translate(i18.common.maxCharsRequired)
@@ -500,9 +500,8 @@ class CustomHouseholdLocationPageState
                                     'required': (_) => localizations.translate(
                                           i18.common.corecommonRequired,
                                         ),
-                                    'sizeLessThan2': (_) =>
-                                        localizations.translate(
-                                            i18.common.min3CharsRequired),
+                                    'minLength': (_) => localizations.translate(
+                                        i18.common.min3CharsRequired),
                                     'maxLength': (object) => localizations
                                         .translate(i18.common.maxCharsRequired)
                                         .replaceAll('{}', maxLength.toString()),

--- a/apps/health_campaign_field_worker_app/pubspec.yaml
+++ b/apps/health_campaign_field_worker_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_campaign_field_worker_app
 description: A new Flutter project.
 publish_to: "none"
-version: 1.7.86
+version: 1.7.91
 
 environment:
   sdk: ">=3.3.0 <=4.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Address fields and postal code now require a minimum of 3 characters during household location registration, improving data consistency and quality in field worker submissions.

* **Chores**
  * Version updated to 1.7.91.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->